### PR TITLE
fix map marshaling

### DIFF
--- a/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-common/src/main/kotlin/pbandk/gen/CodeGenerator.kt
@@ -322,7 +322,7 @@ open class CodeGenerator(val file: File, val kotlinTypeMappings: Map<String, Str
     }
     protected fun File.Field.Standard.sizeExpr(ref: String = fieldRef) = when {
         map ->
-            "pbandk.Sizer.tagSize($number) + pbandk.Sizer.mapSize($ref, $kotlinQualifiedTypeConstructorRef)"
+            "$ref.map { pbandk.Sizer.messageSize($kotlinQualifiedTypeName(it.key, it.value)) + pbandk.Sizer.tagSize($number) }.sum()"
         repeated && packed ->
             "pbandk.Sizer.tagSize($number) + pbandk.Sizer.packedRepeatedSize($ref, pbandk.Sizer::${type.sizeMethod})"
         repeated ->
@@ -332,7 +332,7 @@ open class CodeGenerator(val file: File, val kotlinTypeMappings: Map<String, Str
     }
     protected fun File.Field.Standard.writeExpr(ref: String = fieldRef) = when {
         map ->
-            "protoMarshal.writeTag($tag).writeMap($ref, $kotlinQualifiedTypeConstructorRef)"
+            "$ref.forEach { protoMarshal.writeTag($tag).${type.writeMethod}($kotlinQualifiedTypeName(it.key, it.value)) }"
         repeated && packed ->
             "protoMarshal.writeTag($tag).writePackedRepeated(" +
                 "$ref, pbandk.Sizer::${type.sizeMethod}, protoMarshal::${type.writeMethod})"

--- a/runtime/runtime-jvm/src/test/kotlin/pbandk/MapTest.kt
+++ b/runtime/runtime-jvm/src/test/kotlin/pbandk/MapTest.kt
@@ -1,0 +1,35 @@
+package pbandk
+
+import org.junit.Test
+import pbandk.testpb.Bar
+import pbandk.testpb.Foo
+import pbandk.testpb.MessageWithMap
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MapTest {
+    @Test
+    fun testMap() {
+
+        // This used to fail because it assumed messages could be packed
+        val bytes = byteArrayOf(10, 6, 10, 1, 49, 18, 1, 97, 10, 6, 10, 1, 50, 18, 1, 98)
+        val expected = MessageWithMap(map = mapOf("1" to "a", "2" to "b"))
+
+        assertTrue(expected.protoMarshal().contentEquals(bytes))
+        assertEquals(expected, MessageWithMap.protoUnmarshal(bytes))
+    }
+
+    @Test
+    fun testJavaKotlinInterop() {
+        val java = pbandk.testpb.Test.MessageWithMap
+                .newBuilder()
+                .putMap("1", "a")
+                .putMap("2", "b")
+                .build()
+        val kotlin = MessageWithMap(map = mapOf("1" to "a", "2" to "b"))
+
+        assertEquals(kotlin, MessageWithMap.protoUnmarshal(java.toByteArray()))
+        assertEquals(java, pbandk.testpb.Test.MessageWithMap.parseFrom(kotlin.protoMarshal()))
+        assertTrue(kotlin.protoMarshal().contentEquals(java.toByteArray()))
+    }
+}

--- a/runtime/runtime-jvm/src/test/kotlin/pbandk/testpb/test.kt
+++ b/runtime/runtime-jvm/src/test/kotlin/pbandk/testpb/test.kt
@@ -24,6 +24,31 @@ data class Bar(
     }
 }
 
+data class MessageWithMap(
+    val map: Map<String, String> = emptyMap(),
+    val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message<MessageWithMap> {
+    override operator fun plus(other: MessageWithMap?) = protoMergeImpl(other)
+    override val protoSize by lazy { protoSizeImpl() }
+    override fun protoMarshal(m: pbandk.Marshaller) = protoMarshalImpl(m)
+    companion object : pbandk.Message.Companion<MessageWithMap> {
+        override fun protoUnmarshal(u: pbandk.Unmarshaller) = MessageWithMap.protoUnmarshalImpl(u)
+    }
+
+    data class MapEntry(
+        override val key: String = "",
+        override val value: String = "",
+        val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+    ) : pbandk.Message<MapEntry>, Map.Entry<String, String> {
+        override operator fun plus(other: MapEntry?) = protoMergeImpl(other)
+        override val protoSize by lazy { protoSizeImpl() }
+        override fun protoMarshal(m: pbandk.Marshaller) = protoMarshalImpl(m)
+        companion object : pbandk.Message.Companion<MapEntry> {
+            override fun protoUnmarshal(u: pbandk.Unmarshaller) = MapEntry.protoUnmarshalImpl(u)
+        }
+    }
+}
+
 private fun Foo.protoMergeImpl(plus: Foo?): Foo = plus?.copy(
     unknownFields = unknownFields + plus.unknownFields
 ) ?: this
@@ -71,6 +96,61 @@ private fun Bar.Companion.protoUnmarshalImpl(protoUnmarshal: pbandk.Unmarshaller
     while (true) when (protoUnmarshal.readTag()) {
         0 -> return Bar(pbandk.ListWithSize.Builder.fixed(foos), protoUnmarshal.unknownFields())
         10 -> foos = protoUnmarshal.readRepeatedMessage(foos, pbandk.testpb.Foo.Companion, true)
+        else -> protoUnmarshal.unknownField()
+    }
+}
+
+private fun MessageWithMap.protoMergeImpl(plus: MessageWithMap?): MessageWithMap = plus?.copy(
+    map = map + plus.map,
+    unknownFields = unknownFields + plus.unknownFields
+) ?: this
+
+private fun MessageWithMap.protoSizeImpl(): Int {
+    var protoSize = 0
+    if (map.isNotEmpty()) protoSize += map.map { pbandk.Sizer.messageSize(pbandk.testpb.MessageWithMap.MapEntry(it.key, it.value)) + pbandk.Sizer.tagSize(1) }.sum()
+    protoSize += unknownFields.entries.sumBy { it.value.size() }
+    return protoSize
+}
+
+private fun MessageWithMap.protoMarshalImpl(protoMarshal: pbandk.Marshaller) {
+    if (map.isNotEmpty()) map.forEach { protoMarshal.writeTag(10).writeMessage(pbandk.testpb.MessageWithMap.MapEntry(it.key, it.value)) }
+    if (unknownFields.isNotEmpty()) protoMarshal.writeUnknownFields(unknownFields)
+}
+
+private fun MessageWithMap.Companion.protoUnmarshalImpl(protoUnmarshal: pbandk.Unmarshaller): MessageWithMap {
+    var map: pbandk.MapWithSize.Builder<String, String>? = null
+    while (true) when (protoUnmarshal.readTag()) {
+        0 -> return MessageWithMap(pbandk.MapWithSize.Builder.fixed(map), protoUnmarshal.unknownFields())
+        10 -> map = protoUnmarshal.readMap(map, pbandk.testpb.MessageWithMap.MapEntry.Companion, true)
+        else -> protoUnmarshal.unknownField()
+    }
+}
+
+private fun MessageWithMap.MapEntry.protoMergeImpl(plus: MessageWithMap.MapEntry?): MessageWithMap.MapEntry = plus?.copy(
+    unknownFields = unknownFields + plus.unknownFields
+) ?: this
+
+private fun MessageWithMap.MapEntry.protoSizeImpl(): Int {
+    var protoSize = 0
+    if (key.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(value)
+    protoSize += unknownFields.entries.sumBy { it.value.size() }
+    return protoSize
+}
+
+private fun MessageWithMap.MapEntry.protoMarshalImpl(protoMarshal: pbandk.Marshaller) {
+    if (key.isNotEmpty()) protoMarshal.writeTag(10).writeString(key)
+    if (value.isNotEmpty()) protoMarshal.writeTag(18).writeString(value)
+    if (unknownFields.isNotEmpty()) protoMarshal.writeUnknownFields(unknownFields)
+}
+
+private fun MessageWithMap.MapEntry.Companion.protoUnmarshalImpl(protoUnmarshal: pbandk.Unmarshaller): MessageWithMap.MapEntry {
+    var key = ""
+    var value = ""
+    while (true) when (protoUnmarshal.readTag()) {
+        0 -> return MessageWithMap.MapEntry(key, value, protoUnmarshal.unknownFields())
+        10 -> key = protoUnmarshal.readString()
+        18 -> value = protoUnmarshal.readString()
         else -> protoUnmarshal.unknownField()
     }
 }

--- a/runtime/runtime-jvm/src/test/proto/pbandk/testpb/test.proto
+++ b/runtime/runtime-jvm/src/test/proto/pbandk/testpb/test.proto
@@ -1,10 +1,16 @@
 syntax = "proto3";
 package testpb;
 
+option java_package = "pbandk.testpb";
+
 message Foo {
     string val = 1;
 }
 
 message Bar {
     repeated Foo foos = 1;
+}
+
+message MessageWithMap {
+    map<string, string> map = 1;
 }


### PR DESCRIPTION
We faced a problem with map serialization. Current code serializes map as a packed repeated value which is different from what we see in serialization from scala/java generated sources. 

Please take a look into it, cause we are planning to use it in the nearest future.

Thanks.

