### PR TITLE
Build an artifact compatible with the protobuf gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,14 @@ buildscript {
         maven {
             url 'https://dl.bintray.com/jetbrains/kotlin-native-dependencies'
         }
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-native-gradle-plugin:$kotlin_version"
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.7.RELEASE'
     }
 }
 
@@ -129,6 +133,8 @@ project(':protoc-gen-kotlin:protoc-gen-kotlin-common') {
 project(':protoc-gen-kotlin:protoc-gen-kotlin-jvm') {
     apply plugin: 'kotlin-platform-jvm'
     apply plugin: 'application'
+    apply plugin: 'org.springframework.boot'
+
     sourceCompatibility = '1.8'
     compileKotlin {
         kotlinOptions.jvmTarget = '1.8'
@@ -153,6 +159,17 @@ project(':protoc-gen-kotlin:protoc-gen-kotlin-jvm') {
             exceptionFormat = 'full'
             events 'passed', 'skipped', 'failed'
         }
+    }
+    jar {
+        enabled = true
+    }
+    bootJar {
+        classifier = 'jvm8'
+        launchScript()
+    }
+    configurations.archives.artifacts.removeIf { it.archiveTask.name ==~ /bootDist(Zip|Tar)/ }
+    artifacts {
+        archives bootJar
     }
 
     publishSettings(project, 'protoc-gen-kotlin-jvm', 'JVM library for PBAndK Protobuf code generator')

--- a/examples/browser-js/build.gradle
+++ b/examples/browser-js/build.gradle
@@ -56,10 +56,9 @@ protobuf {
     protoc {
         artifact = 'com.google.protobuf:protoc:3.6.1'
     }
-    // This must be set to the batch file on Windows
     plugins {
         kotlin {
-            path = 'c:\\path\\to\\protoc-gen-kotlin.bat'
+            artifact = 'com.github.cretz.pbandk:protoc-gen-kotlin-jvm:0.3.0:jvm8@jar'
         }
     }
     generateProtoTasks {

--- a/examples/custom-service-gen/README.md
+++ b/examples/custom-service-gen/README.md
@@ -5,9 +5,8 @@ adjacent `gradle-and-jvm` example, this also uses the Protobuf Gradle plugin.
 
 ## Building
 
-Building the `application` project automatically generates the service code. Like the `gradle-and-jvm` example, this
-requires `protoc-gen-kotlin` on the `PATH` (and Windows does require custom `build.gradle` work, see example). To build
-the application with generated source, run:
+Building the `application` project automatically generates the service code. To build the application with generated
+source, run:
 
     path/to/gradle :application:installDist
 

--- a/examples/custom-service-gen/build.gradle
+++ b/examples/custom-service-gen/build.gradle
@@ -36,14 +36,11 @@ project(':application') {
         protoc {
             artifact = 'com.google.protobuf:protoc:3.6.1'
         }
-        /*
-        // This must be set to the batch file on Windows
         plugins {
             kotlin {
-                path = 'c:\\path\\to\\protoc-gen-kotlin.bat'
+                artifact = 'com.github.cretz.pbandk:protoc-gen-kotlin-jvm:0.3.0:jvm8@jar'
             }
         }
-        */
         generateProtoTasks {
             all().each { task ->
                 task.dependsOn ':generator:jar'
@@ -54,7 +51,7 @@ project(':application') {
                     kotlin {
                         option 'log=debug'
                         option 'kotlin_package=pbandk.examples.greeter.pb'
-                        option 'kotlin_service_gen=generator/build/libs/generator.jar|pbandk.examples.greeter.Generator'
+                        option "kotlin_service_gen=${project(':generator').buildDir}/libs/generator.jar|pbandk.examples.greeter.Generator"
                     }
                 }
             }
@@ -63,14 +60,8 @@ project(':application') {
 }
 
 project(':generator') {
-    repositories {
-        flatDir {
-            dirs '../../../protoc-gen-kotlin/protoc-gen-kotlin-jvm/build/libs'
-        }
-    }
-
     dependencies {
         compileOnly 'com.github.cretz.pbandk:pbandk-runtime-jvm:0.3.0'
-        compileOnly name: 'protoc-gen-kotlin-jvm-0.3.0'
+        compileOnly 'com.github.cretz.pbandk:protoc-gen-kotlin-jvm:0.3.0'
     }
 }

--- a/examples/gradle-and-jvm/README.md
+++ b/examples/gradle-and-jvm/README.md
@@ -7,12 +7,9 @@ For this example the generated code has been committed to show what it looks lik
 
 ### Building
 
-To build the code for most platforms with `protoc-gen-kotlin` on the `PATH`, simply run:
+To build the code simply run:
 
     path/to/gradle installDist
-
-On Windows however, since `protoc-gen-kotlin.bat` is not properly read by protoc, you have to uncomment the section in
-`build.gradle` where the path is explicitly set.
 
 ### Running
 

--- a/examples/gradle-and-jvm/build.gradle
+++ b/examples/gradle-and-jvm/build.gradle
@@ -31,14 +31,11 @@ protobuf {
     protoc {
         artifact = 'com.google.protobuf:protoc:3.6.1'
     }
-    /*
-    // This must be set to the batch file on Windows
     plugins {
         kotlin {
-            path = 'c:\\path\\to\\protoc-gen-kotlin.bat'
+            artifact = 'com.github.cretz.pbandk:protoc-gen-kotlin-jvm:0.3.0:jvm8@jar'
         }
     }
-    */
     generateProtoTasks {
         all().each { task ->
             task.builtins {


### PR DESCRIPTION
This ended up being quicker to implement than I thought. Fixes #18.