### PR TITLE
Fix path parsing for the kotlin_service_gen option

### DIFF
--- a/protoc-gen-kotlin/protoc-gen-kotlin-jvm/src/main/kotlin/pbandk/gen/Platform.kt
+++ b/protoc-gen-kotlin/protoc-gen-kotlin-jvm/src/main/kotlin/pbandk/gen/Platform.kt
@@ -34,7 +34,7 @@ actual object Platform {
             // Load up all the JARs
             var loader = javaClass.classLoader
             if (serviceJarList.isNotEmpty()) loader = URLClassLoader(
-                serviceJarList.split(File.pathSeparatorChar).map { File(it).toURI().toURL() }.toTypedArray(),
+                serviceJarList.split(';').map { File(it).toURI().toURL() }.toTypedArray(),
                 loader
             )
             // Create the given name if present


### PR DESCRIPTION
`File.pathSeparatorChar` is `:` on Unix, but `protoc` already uses `:`
to delimit the plugin options from the plugin output directory. So
trying to include a list of paths for the `kotlin_service_gen` option
fails because `protoc` splits on the first `:` character it sees in the
`--kotlin_out` value.

Instead hardcode the path splitting for the `kotlin_service_gen` option
to use `;` (which also happens to be the value of
`File.pathSeparatorChar` on Windows) on all platforms.