### PR TITLE
docs: Make warning about maintenance more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
+### This product is not actively maintained. See [streem/pbandk](https://github.com/streem/pbandk) for a more actively maintained fork.
+
 # PBAndK
 
 PBAndK is a Kotlin code generator and runtime for [Protocol Buffers](https://developers.google.com/protocol-buffers/).
 It is built to work across multiple Kotlin platforms.
-
-**NOTE:** This product is not actively maintained. See https://github.com/streem/pbandk for a more actively maintained fork.
 
 **Features**
 


### PR DESCRIPTION
# Issues

It's still easy to find this repository and open it by mistake due to old references in older articles or just by Googling PBandK.

I've landed here a few times by mistake, and it is a bit deceiving.

![grafik](https://user-images.githubusercontent.com/9389043/158851052-dfdb8e62-8be4-4eae-9ef7-21421f2950ce.png)


# Solution: 

It would be nice if the warning of this repository no longer being maintained was more visible.
